### PR TITLE
fix: align grid scripts/docs with keeper pool key

### DIFF
--- a/contracts/DEPLOYMENT.md
+++ b/contracts/DEPLOYMENT.md
@@ -50,6 +50,15 @@
 
 Before users can place bets, you need to configure a grid using the `configureGrid()` function.
 
+Use this exact pool key (matches keeper/frontend):
+
+- `currency0`: `0x036CbD53842c5426634e7929541eC2318f3dCF7e` (USDC)
+- `currency1`: `0x0000000000000000000000000000000000000000` (native ETH sentinel)
+- `fee`: `0`
+- `tickSpacing`: `60`
+- `hooks`: `0xdbB492353B57698a5443bF1846F00c71EFA41824`
+- `poolId`: `0x83e7f0a67dd9517dc10cb7f40c338e542acc1d132e931483605b05dcc4402463`
+
 **Example Configuration:**
 
 ```solidity

--- a/contracts/DEPLOYMENT_SUMMARY.md
+++ b/contracts/DEPLOYMENT_SUMMARY.md
@@ -56,9 +56,12 @@ You're not creating a USDC/ETH swap pool. Instead:
 ### The Pool Key Explained
 
 When you initialize a pool, you create a `PoolKey`:
-- **currency0:** Dummy placeholder (not used for betting)
-- **currency1:** USDC (what users bet with)
+- **currency0:** USDC (`0x036CbD53842c5426634e7929541eC2318f3dCF7e`)
+- **currency1:** Native ETH sentinel (`0x0000000000000000000000000000000000000000`)
+- **fee:** `0`
+- **tickSpacing:** `60`
 - **hooks:** PariHook address
+- **poolId:** `0x83e7f0a67dd9517dc10cb7f40c338e542acc1d132e931483605b05dcc4402463`
 
 The pool exists only to leverage Uniswap V4's:
 1. Secure custody (PoolManager holds funds)

--- a/contracts/PHASE1_TEST_SUMMARY.md
+++ b/contracts/PHASE1_TEST_SUMMARY.md
@@ -158,7 +158,7 @@ Since window 891 was voided, you can claim your 0.1 USDC back:
 # Create a claim refund script or call directly:
 cast send 0xdbB492353B57698a5443bF1846F00c71EFA41824 \
   "claimRefund((address,address,uint24,int24,address),uint256)" \
-  "(<currency0>,<currency1>,3000,60,<PariHook>)" \
+  "(0x036CbD53842c5426634e7929541eC2318f3dCF7e,0x0000000000000000000000000000000000000000,0,60,0xdbB492353B57698a5443bF1846F00c71EFA41824)" \
   891 \
   --private-key $PRIVATE_KEY \
   --rpc-url $BASE_SEPOLIA_RPC_URL

--- a/contracts/script/SettleWindow.s.sol
+++ b/contracts/script/SettleWindow.s.sol
@@ -37,13 +37,13 @@ contract SettleWindow is Script {
         console.log("============================================\n");
 
         // Create pool key
-        Currency currency0 = Currency.wrap(address(0x0000000000000000000000000000000000000001));
-        Currency currency1 = Currency.wrap(address(0x036CbD53842c5426634e7929541eC2318f3dCF7e));
+        Currency currency0 = Currency.wrap(address(0x036CbD53842c5426634e7929541eC2318f3dCF7e));
+        Currency currency1 = Currency.wrap(address(0));
 
         PoolKey memory poolKey = PoolKey({
             currency0: currency0,
             currency1: currency1,
-            fee: 3000,
+            fee: 0,
             tickSpacing: 60,
             hooks: IHooks(address(PARI_HOOK))
         });

--- a/contracts/script/TestBettingFlow.s.sol
+++ b/contracts/script/TestBettingFlow.s.sol
@@ -67,18 +67,18 @@ contract TestBettingFlow is Script {
         require(usdcBalance >= 1_000_000, "Need at least 1 USDC for testing");
         require(ethBalance > 0, "Need some ETH for gas");
 
-        // Step 2: Create pool key (same as in grid config test)
+        // Step 2: Create pool key (same as keeper/frontend config)
         console.log("--------------------------------------------");
         console.log("STEP 2: Setup Pool Key");
         console.log("--------------------------------------------\n");
 
-        Currency currency0 = Currency.wrap(address(0x0000000000000000000000000000000000000001));
-        Currency currency1 = Currency.wrap(address(USDC));
+        Currency currency0 = Currency.wrap(address(USDC));
+        Currency currency1 = Currency.wrap(address(0));
 
         PoolKey memory poolKey = PoolKey({
             currency0: currency0,
             currency1: currency1,
-            fee: 3000,
+            fee: 0,
             tickSpacing: 60,
             hooks: IHooks(address(PARI_HOOK))
         });
@@ -203,14 +203,14 @@ contract TestBettingFlow is Script {
         console.log("");
 
         console.log("Grid Epoch Info:");
-        // Note: We can't easily read gridEpoch from the mapping, but we know it from config
-        console.log("  Grid starts at epoch: 1772471340");
-        console.log("  Window duration: 60 seconds");
+        (,, uint256 windowDuration,,,, uint256 gridEpoch,,) = PARI_HOOK.gridConfigs(poolId);
+        console.log("  Grid starts at epoch:", gridEpoch);
+        console.log("  Window duration:", windowDuration, "seconds");
         console.log("  Current block.timestamp:", block.timestamp);
 
-        if (block.timestamp < 1772471340) {
+        if (block.timestamp < gridEpoch) {
             console.log("  [WARN] Grid hasn't started yet!");
-            console.log("  Grid starts in:", 1772471340 - block.timestamp, "seconds");
+            console.log("  Grid starts in:", gridEpoch - block.timestamp, "seconds");
         }
         console.log("");
     }

--- a/contracts/script/TestPariHookIntegration.s.sol
+++ b/contracts/script/TestPariHookIntegration.s.sol
@@ -8,6 +8,7 @@ import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {IPyth} from "@pythnetwork/pyth-sdk-solidity/IPyth.sol";
 import {PythStructs} from "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
 
@@ -30,6 +31,8 @@ import {PythStructs} from "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
  * 5. Display next steps for pool initialization
  */
 contract TestPariHookIntegration is Script {
+    using PoolIdLibrary for PoolKey;
+
     // Deployed contract addresses
     PariHook public constant PARI_HOOK = PariHook(0xdbB492353B57698a5443bF1846F00c71EFA41824);
     IPoolManager public constant POOL_MANAGER = IPoolManager(0x05E73354cFDd6745C338b50BcFDfA3Aa6fA03408);
@@ -131,18 +134,18 @@ contract TestPariHookIntegration is Script {
     }
 
     function testConfigureGrid(uint256 adminPrivateKey) internal {
-        // Create a dummy pool key for testing
-        // Note: This is just for configureGrid testing. Actual pool initialization happens later.
-        Currency currency0 = Currency.wrap(address(0x0000000000000000000000000000000000000001)); // Dummy
-        Currency currency1 = Currency.wrap(USDC);
+        // Use the same pool key expected by keeper/frontend.
+        Currency currency0 = Currency.wrap(USDC);
+        Currency currency1 = Currency.wrap(address(0));
 
         PoolKey memory poolKey = PoolKey({
             currency0: currency0,
             currency1: currency1,
-            fee: 3000, // 0.3%
+            fee: 0,
             tickSpacing: 60,
             hooks: IHooks(address(PARI_HOOK))
         });
+        PoolId poolId = poolKey.toId();
 
         // Calculate gridEpoch: 5 minutes from now, aligned to minute boundary
         uint256 currentTime = block.timestamp;
@@ -156,6 +159,7 @@ contract TestPariHookIntegration is Script {
         console.log("  maxStakePerCell: 100000000000 ($100,000)");
         console.log("  feeBps: 200 (2%)");
         console.log("  minPoolThreshold: 1000000 ($1.00)");
+        console.log("  poolId:", vm.toString(PoolId.unwrap(poolId)));
         console.log("  gridEpoch:", gridEpoch);
         console.log("  usdcToken:", USDC);
         console.log("");
@@ -185,14 +189,14 @@ contract TestPariHookIntegration is Script {
     }
 
     function testViewFunctions() internal view {
-        // Create same dummy pool key for querying
-        Currency currency0 = Currency.wrap(address(0x0000000000000000000000000000000000000001));
-        Currency currency1 = Currency.wrap(USDC);
+        // Query the same configured pool key.
+        Currency currency0 = Currency.wrap(USDC);
+        Currency currency1 = Currency.wrap(address(0));
 
         PoolKey memory poolKey = PoolKey({
             currency0: currency0,
             currency1: currency1,
-            fee: 3000,
+            fee: 0,
             tickSpacing: 60,
             hooks: IHooks(address(PARI_HOOK))
         });

--- a/contracts/script/TestSettlement.s.sol
+++ b/contracts/script/TestSettlement.s.sol
@@ -40,8 +40,6 @@ contract TestSettlement is Script {
 
     // Constants
     bytes32 public constant ETH_USD_FEED_ID = 0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace;
-    uint256 public constant GRID_EPOCH = 1772471340;
-    uint256 public constant WINDOW_DURATION = 60;
 
     function run() public view {
         address user = vm.addr(vm.envUint("PRIVATE_KEY"));
@@ -52,16 +50,17 @@ contract TestSettlement is Script {
         console.log("============================================\n");
 
         // Create pool key
-        Currency currency0 = Currency.wrap(address(0x0000000000000000000000000000000000000001));
-        Currency currency1 = Currency.wrap(address(0x036CbD53842c5426634e7929541eC2318f3dCF7e));
+        Currency currency0 = Currency.wrap(address(0x036CbD53842c5426634e7929541eC2318f3dCF7e));
+        Currency currency1 = Currency.wrap(address(0));
 
         PoolKey memory poolKey = PoolKey({
             currency0: currency0,
             currency1: currency1,
-            fee: 3000,
+            fee: 0,
             tickSpacing: 60,
             hooks: IHooks(address(PARI_HOOK))
         });
+        PoolId poolId = poolKey.toId();
 
         // Our bet was on window 891
         uint256 targetWindow = 891;
@@ -92,7 +91,9 @@ contract TestSettlement is Script {
         console.log("STEP 2: Check Timing");
         console.log("--------------------------------------------\n");
 
-        uint256 windowEnd = GRID_EPOCH + ((targetWindow + 1) * WINDOW_DURATION);
+        (,, uint256 windowDuration,,,, uint256 gridEpoch,,) = PARI_HOOK.gridConfigs(poolId);
+
+        uint256 windowEnd = gridEpoch + ((targetWindow + 1) * windowDuration);
         uint256 currentTime = block.timestamp;
 
         console.log("  Window End Time:", windowEnd);


### PR DESCRIPTION
Thanks Fred, confirmed and fixed.
issue #10 fixed
I rechecked PariHook `0xdbB492353B57698a5443bF1846F00c71EFA41824` and you were right: the keeper/frontend pool key was not configured before.

I executed `configureGrid(...)` on Base Sepolia using the exact pool key below:
- currency0: `0x036CbD53842c5426634e7929541eC2318f3dCF7e`
- currency1: `0x0000000000000000000000000000000000000000`
- fee: `0`
- tickSpacing: `60`
- hooks: `0xdbB492353B57698a5443bF1846F00c71EFA41824`
- poolId: `0x83e7f0a67dd9517dc10cb7f40c338e542acc1d132e931483605b05dcc4402463`

Config tx:
https://sepolia.basescan.org/tx/0x6642615500cfc8e8013f63e2348c3e49012b69d03c7d77239075946e8f5dd69c

Grid values now on-chain:
- gridEpoch: `1772808840`
- windowDuration: `60`
- bandWidth: `2000000`
- frozenWindows: `3`
- maxStakePerCell: `100000000000`
- feeBps: `200`
- minPoolThreshold: `1000000`
- pythPriceFeedId: `0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace`

Also confirmed `currentWindowId(poolKey)` now returns `0` (no revert).

Uniswap v4 pool initialization is still pending for this same key (PoolManager slot0 is zero), so next step is `poolManager.initialize(poolKey, sqrtPriceX96)` for this hook/key.
